### PR TITLE
[Template Sync] Update legal copyright information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
   - family-names: "Ravani"
     given-names: "Jay"
     orcid: "https://orcid.org/0009-0008-1307-6983"
-    affiliation: "THD-Spatial-AI"
+    affiliation: "BigGeoData & Spatial AI, Technische Hochschule Deggendorf"
 repository-code: "https://github.com/THD-Spatial-AI/building-configurator"
 url: "https://building-configurator-gui.vercel.app/"
 license: MIT

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 THD-Spatial
+Copyright (c) 2026 BigGeoData & Spatial AI, Technische Hochschule Deggendorf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,4 +123,4 @@ extra_javascript:
 
 # Copyright
 copyright: |
-  &copy; 2026 <a href="https://github.com/THD-Spatial-AI" target="_blank" rel="noopener">THD-Spatial-AI</a>
+  &copy; 2026 <a href="https://github.com/THD-Spatial-AI" target="_blank" rel="noopener">BigGeoData & Spatial AI, Technische Hochschule Deggendorf</a>


### PR DESCRIPTION
## Template Sync: Legal Copyright Update

This PR updates the copyright holder to match the central template.

**New copyright holder:** `BigGeoData & Spatial AI, Technische Hochschule Deggendorf`

**Files updated (where present and changed):**
- `LICENSE` — copyright holder line (license type and year preserved)
- `mkdocs.yml` — `copyright:` field
- `CITATION.cff` — `affiliation:` field(s)
- `README.md` — any copyright lines

---
To opt out of future syncs for specific files, create `.github/.templatesync-ignore` with one filename per line. Use `*` to skip this repo entirely.

*Auto-generated by [GitHub Template Sync](https://github.com/THD-Spatial-AI/github-template)*
